### PR TITLE
fix(transform): concurrent now works

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -24,7 +24,7 @@ module.exports = class PromiseReadStream extends ReadableStream {
     this._keepReading = false
     this._streamDeferred = defer()
     this.wrapRead()
-    this.once('end', this._finishUp)
+    this.once('end', () => this._streamDeferred.resolve())
   }
 
   wrapRead () {
@@ -60,10 +60,6 @@ module.exports = class PromiseReadStream extends ReadableStream {
 
   emitError (e) {
     this.emit('error', e)
-  }
-
-  _finishUp () {
-    this._streamDeferred.resolve()
   }
 
   promise () {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -2,12 +2,6 @@ const Promise = require('bluebird')
 const Transform = require('stream').Transform
 const { defer, maybeResume } = require('./utils')
 
-function nextTick () {
-  return new Promise(function (resolve, reject) {
-    process.nextTick(resolve)
-  })
-}
-
 module.exports = class PromiseTransformStream extends Transform {
   constructor (opts, fn) {
     if (typeof opts === 'function') {
@@ -34,36 +28,30 @@ module.exports = class PromiseTransformStream extends Transform {
     this._streamEnd = defer()
     this._handlingErrors = false
     this._concurrent = opts.concurrent
-    this._queue = []
+    this._queue = new Set()
   }
 
   wrapTransform () {
     const _fn = this._transform
-    this._transform = (data, encoding, done) => {
-      var queue = this._queue
-      var processed = Promise.resolve()
+    this._transform = function (data, encoding, done) {
+      const processed = Promise.resolve()
         .then(() => _fn.call(this, data, encoding))
         .then(data => {
           if (data !== undefined) {
-            this.push(data)
+            return this.push(data)
           }
         })
-      processed.catch(done)
-      queue.push(processed)
-      if (queue.length >= this._concurrent) {
-        var next = queue.shift()
-        // The delay is a workaround for the bad design of
-        // node streams which forbid you to call done twice
-        // at the same tick on the event loop, even if you
-        // had events happening at the exact same tick
-        if (next.isResolved()) {
-          nextTick().then(done, done)
-        } else {
-          next.then(done, done)
-        }
-      } else {
-        done()
+        .then(() => {
+          this._queue.delete(processed)
+        }, e => {
+          this.emitError(e)
+        })
+      this._queue.add(processed)
+
+      if (this._queue.size < this._concurrent) {
+        return done()
       }
+      Promise.race(this._queue).then(() => done(), e => this.emitError(e))
     }
   }
 
@@ -71,7 +59,7 @@ module.exports = class PromiseTransformStream extends Transform {
     const flushCb = this._flush
     this._flush = (done) => {
       Promise.all(this._queue)
-        .then(() => this._finishUp())
+        .then(() => this._streamEnd.resolve())
         .then(() => {
           if (flushCb) {
             return flushCb.call(this)
@@ -81,14 +69,12 @@ module.exports = class PromiseTransformStream extends Transform {
     }
   }
 
-  _finishUp () {
-    this._streamEnd.resolve()
-  }
-
   push (data) {
     return Promise.resolve(data)
-      .bind(this)
-      .then(super.push, this.emitError)
+      .then(
+        data => super.push(data),
+        err => this.emitError(err)
+      )
   }
 
   emitError (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ function defer () {
     resolveCb = resolve
     rejectCb = reject
   })
-  return { resolve: resolveCb, reject: rejectCb, promise: promise }
+  return { resolve: resolveCb, reject: rejectCb, promise }
 }
 
 function maybeResume (stream) {

--- a/test/test.js
+++ b/test/test.js
@@ -24,16 +24,6 @@ function objects () {
     }})
 }
 
-function numbers () {
-  const arr = [1, 2, 3, 4, 5, 6, null]
-  return new Readable({
-    objectMode: true,
-    read () {
-      const value = arr.shift()
-      this.push(value)
-    }})
-}
-
 function nextTick () {
   return new Promise(function (resolve, reject) {
     process.nextTick(resolve)
@@ -142,103 +132,6 @@ describe('bluestream', () => {
       })
       await read.promise()
       assert.equal(arr.length, 0)
-    })
-  })
-
-  describe('PromiseTransformStream', () => {
-    it('works with .push', async () => {
-      let transform = bstream.transform(function (data) {
-        this.push(data)
-      })
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 21)
-    })
-
-    it('works with .push of a promise', async () => {
-      let transform = bstream.transform(function (data) {
-        this.push(Promise.resolve(data))
-      })
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 21)
-    })
-
-    it('pushes a return value', async () => {
-      let transform = bstream.transform(data => data)
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 21)
-    })
-
-    it('pushes a promise return', async () => {
-      let transform = bstream.transform(async function (data) {
-        return data
-      })
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 21)
-    })
-
-    it('allows not returning a value', async () => {
-      let transform = bstream.transform(data => {
-        if (data !== 2) {
-          return data
-        }
-      })
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 19)
-    })
-
-    it('allows not calling .push in a call', async () => {
-      let transform = bstream.transform(function (data) {
-        if (data !== 2) {
-          return data
-        }
-      })
-      let sum = 0
-      transform.on('data', data => {
-        sum += data
-      })
-      await bstream.pipe(numbers(), transform)
-      assert.equal(sum, 19)
-    })
-
-    it('#promise()', async () => {
-      let count = 0
-      let transform = bstream.transform(data => count++)
-      await bstream.pipe(numbers(), transform)
-      assert.equal(count, 6)
-    })
-
-    it('supports writable objects and readable buffers', async () => {
-      let transform = new bstream.PromiseTransformStream({
-        writableObjectMode: true,
-        readableObjectMode: false,
-        transform ({ value }) {
-          const data = value.toString()
-          this.push(data)
-        }
-      })
-
-      bstream.pipe(objects(), transform)
-      assert.deepEqual(await bstream.collect(transform), Buffer.from('123456'))
     })
   })
 

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -1,0 +1,146 @@
+
+const Promise = require('bluebird')
+const Readable = require('stream').Readable
+const assert = require('chai').assert
+const bstream = require('../')
+const defer = require('../lib/utils').defer
+
+function objects () {
+  const arr = [1, 2, 3, 4, 5, 6]
+  return new Readable({
+    objectMode: true,
+    read () {
+      const value = arr.shift()
+      this.push(value ? { value } : null)
+    }
+  })
+}
+
+function numbers () {
+  const arr = [1, 2, 3, 4, 5, 6, null]
+  return new Readable({
+    objectMode: true,
+    read () {
+      const value = arr.shift()
+      this.push(value)
+    }})
+}
+
+describe('PromiseTransformStream', () => {
+  it('works with .push', async () => {
+    let transform = bstream.transform(function (data) {
+      this.push(data)
+    })
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 21)
+  })
+
+  it('works with .push of a promise', async () => {
+    let transform = bstream.transform(function (data) {
+      this.push(Promise.resolve(data))
+    })
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 21)
+  })
+
+  it('pushes a return value', async () => {
+    let transform = bstream.transform(data => data)
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 21)
+  })
+
+  it('pushes a promise return', async () => {
+    let transform = bstream.transform(async function (data) {
+      return data
+    })
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 21)
+  })
+
+  it('allows not returning a value', async () => {
+    let transform = bstream.transform(data => {
+      if (data !== 2) {
+        return data
+      }
+    })
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 19)
+  })
+
+  it('allows not calling .push in a call', async () => {
+    let transform = bstream.transform(function (data) {
+      if (data !== 2) {
+        return data
+      }
+    })
+    let sum = 0
+    transform.on('data', data => {
+      sum += data
+    })
+    await bstream.pipe(numbers(), transform)
+    assert.equal(sum, 19)
+  })
+
+  it('#promise()', async () => {
+    let count = 0
+    let transform = bstream.transform(data => count++)
+    await bstream.pipe(numbers(), transform)
+    assert.equal(count, 6)
+  })
+
+  it('supports writable objects and readable buffers', async () => {
+    let transform = new bstream.PromiseTransformStream({
+      writableObjectMode: true,
+      readableObjectMode: false,
+      transform ({ value }) {
+        const data = value.toString()
+        this.push(data)
+      }
+    })
+
+    bstream.pipe(objects(), transform)
+    assert.deepEqual(await bstream.collect(transform), Buffer.from('123456'))
+  })
+
+  it('allows for concurrent operations', async () => {
+    // resolve the promise from the deferred on the 2nd data event
+    const defered = defer()
+    let transform = bstream.transform({ concurrent: 2, log: true }, async data => {
+      if (data === 1) {
+        return defered.promise
+      }
+      if (data === 2) {
+        defered.resolve(1)
+        return Promise.resolve(2)
+      }
+      if (data === 'end') {
+        return null
+      }
+    })
+    transform.write(1)
+    transform.write(2)
+    transform.write('end')
+    const data = await bstream.collect(transform)
+    assert.deepEqual(data, [1, 2])
+  })
+})


### PR DESCRIPTION
The old concurrency model was copied from promise stream and had some issues with events finishing at different times. We now use a set to figure out what's still in flight and let promises remove themselves, no timing required.