### PR TITLE
A lot of features

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,13 +1,21 @@
 const PromiseTransformStream = require('./transform')
 
-module.exports = class PromiseMapStream extends PromiseTransformStream {
-  constructor (opts, fn) {
-    super(opts, fn)
-    this._filterFn = this._fn
-    this._fn = data => {
-      if (this._filterFn(data)) {
-        return this.push(data)
-      }
+module.exports = class PromiseFilterStream extends PromiseTransformStream {
+  constructor (opts, filterFunction) {
+    if (typeof opts === 'function') {
+      filterFunction = opts
+      opts = {}
     }
+    super(opts)
+    this._filterFunction = filterFunction
+  }
+
+  _transform (data, encoding) {
+    return Promise.resolve(this._filterFunction(data, encoding))
+      .then(keep => {
+        if (keep) {
+          this.push(data)
+        }
+      })
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,17 @@
 const Buffer = require('buffer').Buffer
-const { maybeResume, promiseFinally } = require('./utils')
+const { maybeResume, promiseFinally, defer } = require('./utils')
 const PromiseReadStream = require('./read')
 const PromiseTransformStream = require('./transform')
-const PromiseMapStream = require('./map')
 const PromiseFilterStream = require('./filter')
 const PromiseReduceStream = require('./reduce')
+const PromiseWriteStream = require('./write')
+
+const read = (opts, readFn) => new PromiseReadStream(opts, readFn)
+const write = (opts, writeFn) => new PromiseWriteStream(opts, writeFn)
+const transform = (opts, fn) => new PromiseTransformStream(opts, fn)
+const map = transform
+const filter = (opts, fn) => new PromiseFilterStream(opts, fn)
+const reduce = (opts, fn, initial) => new PromiseReduceStream(opts, fn, initial)
 
 function wait (stream) {
   if (typeof stream.promise === 'function') {
@@ -20,75 +27,73 @@ function wait (stream) {
 }
 
 function collect (stream) {
-  var acc = []
-  return pipe(stream, maybeResume(new PromiseTransformStream(data => {
-    acc.push(data)
-  }))).then(function () {
-    if (!acc.length) {
-      return null
-    }
-    if (typeof acc[0] === 'string') {
-      return acc.join('')
-    }
-    if (Buffer.isBuffer(acc[0])) {
-      return Buffer.concat(acc)
-    }
-    return acc
-  })
+  const acc = []
+  return pipe(stream, write(data => acc.push(data)))
+    .then(() => {
+      if (acc.length === 0) {
+        return null
+      }
+      if (typeof acc[0] === 'string') {
+        return acc.join('')
+      }
+      if (Buffer.isBuffer(acc[0])) {
+        return Buffer.concat(acc)
+      }
+      return acc
+    })
 }
 
-function pipe (source, sink) {
-  var _resolve, _reject
-  const streamDone = new Promise(function (resolve, reject) {
-    _resolve = resolve
-    _reject = reject
-    source
-      .on('error', reject)
-    sink
-      .on('error', reject)
-      .on('finish', resolve)
-      .on('end', resolve)
-
-    source.pipe(sink)
-  })
-  return promiseFinally(streamDone, function () {
-    source.removeListener('error', _reject)
-    sink.removeListener('error', _reject)
-    sink.removeListener('finish', _resolve)
-    sink.removeListener('end', _resolve)
-  })
-}
-
-function pipeline () {
-  var arr = []
-  for (var k = 1; k < arguments.length; ++k) {
-    arr.push(pipe(arguments[k - 1], arguments[k]))
+function pipe () {
+  const streams = Array.from(arguments)
+  if (streams.length < 2) {
+    throw new TypeError('Must pipe to two or more streams')
   }
-  return Promise.all(arr)
-}
+  const pipeDone = defer()
 
-const read = (opts, readFn) => new PromiseReadStream(opts, readFn)
-const transform = (opts, fn) => new PromiseTransformStream(opts, fn)
-const map = (opts, fn) => new PromiseMapStream(opts, fn)
-const filter = (opts, fn) => new PromiseFilterStream(opts, fn)
-const reduce = (opts, fn, initial) => new PromiseReduceStream(opts, fn, initial)
+  streams.forEach((stream, index) => {
+    stream.on('error', pipeDone.reject)
+
+    const lastStream = index + 1 === streams.length
+    if (!lastStream) {
+      const nextStream = streams[index + 1]
+      stream.pipe(nextStream)
+    }
+  })
+
+  const sink = streams[streams.length - 1]
+  sink.on('finish', pipeDone.resolve)
+  sink.on('end', pipeDone.resolve)
+
+  return promiseFinally(pipeDone.promise, function () {
+    streams.forEach(stream => {
+      stream.removeListener('error', pipeDone.reject)
+    })
+    sink.removeListener('finish', pipeDone.resolve)
+    sink.removeListener('end', pipeDone.resolve)
+  })
+}
 
 module.exports = {
   // utilities
   wait,
   collect,
   pipe,
-  pipeline,
+  pipeline: pipe,
 
   // constructors
   read,
   PromiseReadStream,
+
   transform,
   PromiseTransformStream,
   map,
-  PromiseMapStream,
+
+  write,
+  PromiseWriteStream,
+
   filter,
   PromiseFilterStream,
+
   reduce,
   PromiseReduceStream
 }

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,9 +1,0 @@
-const PromiseTransformStream = require('./transform')
-
-module.exports = class PromiseMapStream extends PromiseTransformStream {
-  constructor (opts, fn) {
-    super(opts, fn)
-    this._mapfn = this._fn
-    this._fn = data => this.push(this._mapfn(data))
-  }
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 function defer () {
-  var resolveCb, rejectCb
-  var promise = new Promise(function (resolve, reject) {
+  let resolveCb, rejectCb
+  const promise = new Promise(function (resolve, reject) {
     resolveCb = resolve
     rejectCb = reject
   })
@@ -15,7 +15,7 @@ function maybeResume (stream) {
 }
 
 function promiseFinally (promise, callback) {
-  const fin = () => Promise.resolve(callback).then(() => promise)
+  const fin = () => Promise.resolve(callback()).then(() => promise)
   return promise.then(fin, fin)
 }
 

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,15 +1,15 @@
-const Transform = require('stream').Transform
+const Writable = require('stream').Writable
 const { defer, maybeResume } = require('./utils')
 
-module.exports = class PromiseTransformStream extends Transform {
+module.exports = class PromiseWriteStream extends Writable {
   constructor (opts, fn) {
     if (typeof opts === 'function') {
       fn = opts
       opts = {}
     }
 
-    if (!opts.transform && fn) {
-      opts.transform = fn
+    if (!opts.write && fn) {
+      opts.write = fn
     }
 
     opts = Object.assign({
@@ -17,29 +17,24 @@ module.exports = class PromiseTransformStream extends Transform {
     }, opts)
 
     // only if the user hasn't suggested anything about object mode do we default to object mode
-    if (!('objectMode' in opts) && !('writableObjectMode' in opts) && !('readableObjectMode' in opts)) {
+    if (!('objectMode' in opts) && !('writableObjectMode' in opts)) {
       opts.objectMode = true
     }
 
     super(opts)
-    this.wrapTransform()
-    this.wrapFlush()
+    this.wrapWrite()
     this._streamEnd = defer()
     this._handlingErrors = false
     this._concurrent = opts.concurrent
     this._queue = new Set()
+    this.once('finish', () => this._streamEnd.resolve())
   }
 
-  wrapTransform () {
-    const _fn = this._transform
-    this._transform = function (data, encoding, done) {
+  wrapWrite () {
+    const _fn = this._write
+    this._write = function (data, encoding, done) {
       const processed = Promise.resolve()
         .then(() => _fn.call(this, data, encoding))
-        .then(data => {
-          if (data !== undefined) {
-            return this.push(data)
-          }
-        })
         .then(() => {
           this._queue.delete(processed)
         }, e => {
@@ -52,28 +47,6 @@ module.exports = class PromiseTransformStream extends Transform {
       }
       Promise.race(this._queue).then(() => done(), e => this.emitError(e))
     }
-  }
-
-  wrapFlush () {
-    const flushCb = this._flush
-    this._flush = (done) => {
-      Promise.all(this._queue)
-        .then(() => this._streamEnd.resolve())
-        .then(() => {
-          if (flushCb) {
-            return flushCb.call(this)
-          }
-        })
-        .then(data => done(null, data), done)
-    }
-  }
-
-  push (data) {
-    return Promise.resolve(data)
-      .then(
-        data => super.push(data),
-        err => this.emitError(err)
-      )
   }
 
   emitError (error) {

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -1,0 +1,28 @@
+const { Readable } = require('stream')
+const bstream = require('../')
+
+function numbers () {
+  const arr = [1, 2, 3, 4, 5, 6, null]
+  return new Readable({
+    objectMode: true,
+    read () {
+      const value = arr.shift()
+      this.push(value)
+    }})
+}
+
+describe('PromiseFilterStream', () => {
+  it('Filters based upon the passed in function', async () => {
+    const filter = bstream.filter(data => (data % 2) === 0)
+    numbers().pipe(filter)
+    const evenNumbers = await bstream.collect(filter)
+    assert.deepEqual(evenNumbers, [2, 4, 6])
+  })
+
+  it('Filters based upon the passed in async function', async () => {
+    const filter = bstream.filter(async data => (data % 2) === 0)
+    numbers().pipe(filter)
+    const evenNumbers = await bstream.collect(filter)
+    assert.deepEqual(evenNumbers, [2, 4, 6])
+  })
+})

--- a/test/utilites-test.js
+++ b/test/utilites-test.js
@@ -27,9 +27,9 @@ function nextTick () {
   })
 }
 
-describe('wait', () => {
+describe('#wait', () => {
   it('bstream.wait', async () => {
-    var last = 0
+    let last = 0
     await bstream.wait(lines().pipe(bstream.map(async (el) => {
       await nextTick()
       if (el) { last = el }
@@ -39,7 +39,7 @@ describe('wait', () => {
   })
 })
 
-describe('collect', () => {
+describe('#collect', () => {
   it('collect()', function () {
     return bstream.collect(rawString()).then(function (data) {
       assert.equal(data.length, 18 * 3, 'test.txt should be the correct size')
@@ -56,10 +56,22 @@ describe('collect', () => {
   })
 })
 
+describe('#pipe', () => {
+  it('pipes multiple streams together', async () => {
+    const numbers = []
+    const extract = objects()
+    const transform = bstream.filter(({ value }) => value % 2 === 0)
+    const load = bstream.write(({ value }) => numbers.push(value))
+
+    await bstream.pipe(extract, transform, load)
+    assert.deepEqual(numbers, [2, 4, 6])
+  })
+})
+
 describe('error', () => {
-  it('error', function () {
-    return lines().pipe(bstream.map(function (el) {
-      return Promise.reject(new Error('Oops'))
+  it('error', async function () {
+    await lines().pipe(bstream.map(async (el) => {
+      throw new Error('Oops')
     })).wait().then(function (val) {
       assert.ok(false, 'should not execute')
     }, function (e) {

--- a/test/write-test.js
+++ b/test/write-test.js
@@ -1,0 +1,59 @@
+const Readable = require('stream').Readable
+const assert = require('chai').assert
+const bstream = require('../')
+const defer = require('../lib/utils').defer
+
+function numbers () {
+  const arr = [1, 2, 3, 4, 5, 6, null]
+  return new Readable({
+    objectMode: true,
+    read () {
+      const value = arr.shift()
+      this.push(value)
+    }})
+}
+
+describe('PromiseWriteStream', () => {
+  it('works with an async function', async () => {
+    let count = 0
+    let writer = bstream.write(async function (data) {
+      count += data
+    })
+    await bstream.pipe(numbers(), writer)
+    assert.equal(count, 21)
+  })
+
+  it('works with a function', async () => {
+    let count = 0
+    let writer = bstream.write(function (data) {
+      count += data
+    })
+    await bstream.pipe(numbers(), writer)
+    assert.equal(count, 21)
+  })
+
+  it('#promise()', async () => {
+    let count = 0
+    let writer = bstream.write(data => count++)
+    numbers().pipe(writer)
+    await writer.promise()
+    assert.equal(count, 6)
+  })
+
+  it('allows for concurrent operations', async () => {
+    // resolve the promise from the deferred on the 2nd data event
+    const defered = defer()
+    let writer = bstream.write({ concurrent: 2 }, async data => {
+      if (data === 1) {
+        return defered.promise
+      }
+      if (data === 2) {
+        defered.resolve()
+      }
+    })
+    writer.write(1)
+    writer.write(2)
+    writer.end()
+    await writer.promise()
+  })
+})


### PR DESCRIPTION
feat: Add a Writeable Stream
feat(pipe): Make `pipe` act like `pipeline` and remove `pipeline`
feat(map): remove the map stream as it was the same thing as `transform`
fix(pipe): Fix a small leak with error listeners on pipe
fix(filter): It didn't work and wasn't tested

MAJOR: removed `pipeline()` in favor of `pipe()`
MAJOR: removed `map()` and `PromiseMapStream` in favor of `transform()`