### PR TITLE
fix(read): issues with ending read streams with promise pushes

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -21,7 +21,9 @@ module.exports = class PromiseReadStream extends ReadableStream {
     this._handlingErrors = false
     this._reading = false
     this._keepReading = false
+    this._ending = false
     this._streamDeferred = defer()
+    this._pushQueue = new Set()
     this.wrapRead()
     this.once('end', () => this._streamDeferred.resolve())
   }
@@ -37,24 +39,45 @@ module.exports = class PromiseReadStream extends ReadableStream {
       Promise.resolve()
         .then(() => readCb.call(this, bytes))
         .then(data => {
-          this._reading = false
           if (data !== undefined) {
             this.push(data)
           }
+          return Promise.all(this._pushQueue)
+        })
+        .then(() => {
+          this._reading = false
           if (this._keepReading) {
             this._read()
           }
-        }, this.emitError)
+        })
+        .catch(err => this.emitError(err))
     }
   }
 
   push (data) {
-    return Promise.resolve(data)
+    if (data === null) {
+      return this._endingPush()
+    }
+    const readOperation = Promise.resolve(data)
       .then(data => {
-        this._keepReading = super.push(data)
-      }, err => {
-        this.emitError(err)
+        this._pushQueue.delete(readOperation)
+        if (data === null) {
+          return this._endingPush()
+        }
+        this._keepReading = super.push(data) && !this._ending
       })
+      .catch(err => this.emitError(err))
+    this._pushQueue.add(readOperation)
+    return readOperation
+  }
+
+  _endingPush () {
+    this._keepReading = false
+    this._ending = true
+    return Promise
+      .all(this._pushQueue)
+      .then(() => super.push(null))
+      .catch(err => this.emitError(err))
   }
 
   emitError (e) {


### PR DESCRIPTION
- `this.push(null)` or `return null` now ensures to happen after any outstanding `this.push()` promises have resolved.
- `_read` will no longer be called after the stream has ended and there are outstanding async operations