### PR TITLE
feat: upgrade to node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ notifications:
 node_js:
   - '9'
   - '8'
-  - '6'
 after_success:
   - npm run semantic-release
 branches:

--- a/lib/transform.ts
+++ b/lib/transform.ts
@@ -104,7 +104,7 @@ export class TransformStream extends Transform implements IBluestream {
         return this.end(cb)
       }
       if ((this as any)._writableState.pendingcb > 0) {
-        process.nextTick(() => this.end(cb))
+        setImmediate(() => this.end(cb))
         return
       }
       Transform.prototype.end.call(this, cb)

--- a/lib/write.ts
+++ b/lib/write.ts
@@ -83,7 +83,7 @@ export class WriteStream extends Writable implements IBluestream {
         return this.end(cb)
       }
       if ((this as any)._writableState.pendingcb > 0) {
-        return process.nextTick(() => this.end(cb))
+        return setImmediate(() => this.end(cb))
       }
       Writable.prototype.end.call(this, cb)
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^2.7.2"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "eslintConfig": {
     "env": {

--- a/test/read-test.ts
+++ b/test/read-test.ts
@@ -1,8 +1,8 @@
 import { assert } from 'chai'
 import { read, ReadStream, wait } from '../lib'
 
-function nextTick (data?) {
-  return new Promise(resolve => process.nextTick(() => resolve(data)))
+function promiseImmediate (data?) {
+  return new Promise(resolve => setImmediate(() => resolve(data)))
 }
 
 describe('ReadStream', () => {
@@ -118,8 +118,8 @@ describe('ReadStream', () => {
     let callCount = 0
     const stream = read(function () {
       callCount++
-      this.push(nextTick(1))
-      this.push(nextTick(2))
+      this.push(promiseImmediate(1))
+      this.push(promiseImmediate(2))
       return null
     })
     let sum = 0
@@ -135,8 +135,8 @@ describe('ReadStream', () => {
     let callCount = 0
     const stream = read(function () {
       callCount++
-      this.push(nextTick(1))
-      this.push(nextTick(2))
+      this.push(promiseImmediate(1))
+      this.push(promiseImmediate(2))
       this.push(null)
     })
     let sum = 0
@@ -153,17 +153,17 @@ describe('ReadStream', () => {
     let pushCount = 0
     const stream = read(async function () {
       callCount++
-      this.push(await nextTick(1))
+      this.push(await promiseImmediate(1))
       pushCount++
-      this.push(await nextTick(2))
+      this.push(await promiseImmediate(2))
       pushCount++
     })
     let sum = 0
     stream.on('data', data => {
       sum += data
     })
-    await nextTick()
-    await nextTick()
+    await promiseImmediate()
+    await promiseImmediate()
     assert.equal(1, pushCount)
     stream.push(null)
     await wait(stream)

--- a/test/utilites-test.ts
+++ b/test/utilites-test.ts
@@ -22,15 +22,15 @@ function objects () {
     }})
 }
 
-function nextTick () {
-  return new Promise(resolve => process.nextTick(resolve))
+function promiseImmediate (data?) {
+  return new Promise(resolve => setImmediate(() => resolve(data)))
 }
 
 describe('#wait', () => {
   it('waits until the stream ends', async () => {
     let last = '0'
     await wait(lines().pipe(map(async el => {
-      await nextTick()
+      await promiseImmediate()
       if (el) { last = el }
       return el
     })))

--- a/test/write-test.ts
+++ b/test/write-test.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream'
-import { defer } from '../lib/utils'
 import * as bstream from '../lib'
+import { defer } from '../lib/utils'
 
 function numbers (num = 6) {
   const arr = [...new Array(num)].map((val, i) => i + 1)
@@ -12,7 +12,7 @@ function numbers (num = 6) {
       if (value % 2 === 0) {
         this.push(value)
       } else {
-        process.nextTick(() => this.push(value))
+        setImmediate(() => this.push(value))
       }
     }})
 }
@@ -21,8 +21,8 @@ function delay (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function nextTick () {
-  return new Promise(resolve => process.nextTick(resolve))
+function promiseImmediate (data?) {
+  return new Promise(resolve => setImmediate(() => resolve(data)))
 }
 
 describe('WriteStream', () => {
@@ -105,7 +105,7 @@ describe('WriteStream', () => {
     let finished = 0
     const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, null]
     const source = bstream.read(async function () {
-      await nextTick()
+      await promiseImmediate()
       this.push(numbers.shift())
       this.push(numbers.shift())
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": false,
-    "target": "es2015",
+    "target": "es2017",
     "moduleResolution": "node",
     "module": "commonjs",
     "declaration": true


### PR DESCRIPTION
- Use native async/await and don't transpile that (ts target 2017)
- Use `setImmediate` instead of `process.nextTick` as that's the correct way to wait for IO to finish. The only reason it worked before was a side effect of the generator based async/await that typescript gave us.

BREAKING CHANGE: We now require node 8 and use native async/await