### PR TITLE
feat: batch stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,31 @@ await pipe(
 // Ghoul(1)
 // Ghoul(2)
 // Ghoul(3)
-// ... endless Ghouls
+// ... 👻
+```
+
+## batch
+```ts
+batch(batchSize: number) => BatchStream
+new BatchStream(batchSize: number)
+```
+
+A stream that collects a given number of objects and emits them in an array.
+
+```ts
+import { batch, pipe, write } from 'bluestream'
+import { turkeyGenerator } from './util'
+
+await pipe(
+  turkeyGenerator(),
+  batch(2),
+  write(console.log)
+)
+// [turkey, turkey]
+// [turkey, turkey]
+// [turkey, turkey]
+// [turkey, turkey]
+// ... 🐧🐧
 ```
 
 ## wait

--- a/lib/batch-test.ts
+++ b/lib/batch-test.ts
@@ -1,0 +1,30 @@
+import { assert } from 'chai'
+import { Readable } from 'stream'
+import { batch, collect } from './'
+
+function numbers () {
+  const arr = [1, 2, 3, 4, 5, 6, 7, null]
+  return new Readable({
+    objectMode: true,
+    read () {
+      this.push(arr.shift())
+    }})
+}
+
+describe('BatchStream', () => {
+  it('batches in sizes', async () => {
+    const batchStream = batch(2)
+    numbers().pipe(batchStream)
+    const nums = await collect(batchStream)
+    assert.deepEqual(nums, [[1, 2], [3, 4], [5, 6], [7]])
+  })
+  it('flushes whats left', async () => {
+    const batchStream = batch(100)
+    numbers().pipe(batchStream)
+    const nums = await collect(batchStream)
+    assert.deepEqual(nums, [[1, 2, 3, 4, 5, 6, 7]])
+  })
+  it('throws with a bad batch size', async () => {
+    assert.throws(() => batch(0))
+  })
+})

--- a/lib/batch.ts
+++ b/lib/batch.ts
@@ -1,0 +1,36 @@
+import { TransformStream } from './transform'
+
+export class BatchStream extends TransformStream {
+  private batchSize: number
+  private nextBatch: any[]
+
+  constructor (batchSize: number) {
+    super({
+      concurrent: 1,
+      highWaterMark: 1,
+    })
+    if (batchSize <= 0) {
+      throw new TypeError('"batchSize" must be greater than 0')
+    }
+    this.batchSize = batchSize
+    this.nextBatch = []
+  }
+
+  public async _transform (data: any) {
+    this.nextBatch.push(data)
+    if (this.nextBatch.length < this.batchSize) {
+      return
+    }
+    const nextBatch = this.nextBatch
+    this.nextBatch = []
+    return nextBatch
+  }
+
+  public _flush () {
+    const nextBatch = this.nextBatch
+    this.nextBatch = []
+    return nextBatch
+  }
+}
+
+export const batch = (batchSize: number) => new BatchStream(batchSize)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+import { batch, BatchStream } from './batch'
 import { collect } from './collect'
 import { filter, FilterStream, IFilterFunction } from './filter'
 import { iterate } from './iterate'
@@ -26,6 +27,8 @@ export {
 
 // methods
 export {
+  batch,
+  BatchStream,
   collect,
   filter,
   FilterStream,

--- a/lib/iterate-test.ts
+++ b/lib/iterate-test.ts
@@ -21,10 +21,6 @@ function nativeObjectStream () {
     }})
 }
 
-function nativeStringStream () {
-  return createReadStream(join(__dirname, 'small-text.txt'), 'utf8')
-}
-
 function bufferStream () {
   const values = [Buffer.from('12'), Buffer.from('3'), Buffer.from('4'), null]
   return read({ objectMode: false }, () => values.shift())
@@ -80,7 +76,6 @@ describe('iterate', () => {
     assert.deepEqual(asyncArray, [1, 2, 3])
   })
   it('supports async iterators with buffers', async () => {
-    const arr = [1, 2, 3, null]
     const stream = bufferStream()
     const valuesArray: any[] = []
     for await (const val of stream) {

--- a/lib/read-test.ts
+++ b/lib/read-test.ts
@@ -1,11 +1,5 @@
 import { assert } from 'chai'
-import { createReadStream } from 'fs'
-import { join } from 'path'
 import { read, ReadStream, wait } from './'
-
-function stringStream () {
-  return createReadStream(join(__dirname, 'small-text.txt'), 'utf8')
-}
 
 function bufferStream () {
   const values = [Buffer.from('12'), Buffer.from('3'), Buffer.from('4'), null]
@@ -200,7 +194,6 @@ describe('ReadStream', () => {
   })
 
   it('supports async iterators with buffers', async () => {
-    const arr = [1, 2, 3, null]
     const stream = bufferStream()
     const valuesArray: any[] = []
     for await (const val of (stream as any)) {

--- a/lib/reduce.ts
+++ b/lib/reduce.ts
@@ -1,6 +1,6 @@
 import { ITransformStreamOptions, TransformStream } from './transform'
 
-async function reduceStreamFn (value, encoding) {
+async function reduceStreamFn (this: ReduceStream, value, encoding) {
   const currentValue = await Promise.resolve(value)
   if (this.acc === undefined) {
     this.acc = currentValue
@@ -13,8 +13,8 @@ async function reduceStreamFn (value, encoding) {
 export type IReduceFunction = (acc: any, currentValue: any, encoding: string) => Promise<any> | any
 
 export class ReduceStream extends TransformStream {
-  private reduceFn: IReduceFunction
-  private acc: any
+  protected acc: any
+  protected reduceFn: IReduceFunction
 
   constructor (opts: ITransformStreamOptions | IReduceFunction, reduceFn: IReduceFunction | any, initial?: any) {
     if (typeof opts === 'function') {

--- a/lib/transform-test.ts
+++ b/lib/transform-test.ts
@@ -172,7 +172,7 @@ describe('TransformStream', () => {
 
   it('#promise()', async () => {
     let count = 0
-    const stream = transform(data => count++)
+    const stream = transform(() => count++)
     numbers().pipe(stream)
     await stream.promise()
     assert.equal(count, 6)

--- a/lib/utilites-test.ts
+++ b/lib/utilites-test.ts
@@ -78,9 +78,9 @@ describe('#pipe', () => {
 
 describe('error', () => {
   it('error', async () => {
-    await lines().pipe(map(async el => {
+    await lines().pipe(map(async () => {
       throw new Error('Oops')
-    })).promise().then(val => {
+    })).promise().then(() => {
       assert.ok(false, 'should not execute')
     }, e => {
       assert.ok(e, 'should be rejected')

--- a/lib/write-test.ts
+++ b/lib/write-test.ts
@@ -4,7 +4,7 @@ import { pipe, read, write, WriteStream } from '../lib'
 import { defer } from '../lib/utils'
 
 function numbers (num = 6) {
-  const arr: Array<number|null> = [...new Array(num)].map((val, i) => i + 1)
+  const arr: Array<number|null> = [...new Array(num)].map((_, i) => i + 1)
   arr.push(null)
   return new Readable({
     objectMode: true,
@@ -59,7 +59,7 @@ describe('WriteStream', () => {
 
   it('#promise()', async () => {
     let count = 0
-    const writer = write(data => count++)
+    const writer = write(() => count++)
     numbers().pipe(writer)
     await writer.promise()
     assert.equal(count, 6)

--- a/lib/write.ts
+++ b/lib/write.ts
@@ -2,7 +2,7 @@ import { Writable, WritableOptions } from 'stream'
 import { IBluestream } from './interfaces'
 import { defer, maybeResume } from './utils'
 
-async function writeHandler (data, encoding, done) {
+async function writeHandler (this: WriteStream, data, encoding, done) {
   const processed = this.asyncWrite(data, encoding)
     .then(() => {
       this.queue.delete(processed)
@@ -26,9 +26,9 @@ export interface IWritableStreamOptions extends WritableOptions {
 
 export class WriteStream extends Writable implements IBluestream {
   public concurrent: number
-  private asyncWrite: IWriteFunction
+  protected asyncWrite: IWriteFunction
+  protected queue: Set<Promise<any>>
   private handlingErrors: boolean
-  private queue: Set<Promise<any>>
   private streamEnd
 
   constructor (inputOpts: IWritableStreamOptions | IWriteFunction, fn?: IWriteFunction) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "test": "npm run unit-test && npm run lint",
     "unit-test": "mocha --opts lib/mocha.opts",
-    "lint": "tsc && tslint lib/*.ts",
-    "format": "tslint lib/*.ts --fix",
+    "lint": "tsc && tslint -p tsconfig-test.json lib/*.ts",
+    "format": "tslint -p tsconfig-test.json lib/*.ts --fix",
     "build": "tsc",
     "prepare": "npm run build"
   },

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "dist",
+    "strict": false,
     "strictNullChecks": true,
     "target": "es2017",
     "lib": [

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     "no-console": true,
     "no-empty-interface": false,
     "no-empty": false,
+    "no-use-before-declare":true,
     "no-return-await": true,
     "quotemark": [true, "single", "avoid-escape", "avoid-template"],
     "semicolon": [true, "never"],


### PR DESCRIPTION
- `batch(batchSize: number) => BatchStream`
- tighten up some of the strict typings