### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ cache:
 notifications:
   email: false
 node_js:
+  - 'node'
   - '10'
-  - '9'
   - '8'
+install: npm install
 after_success:
   - npm run semantic-release
 branches:


### PR DESCRIPTION
Node.js 9 already reached its EOL. We should test the current stable (`node`).

See https://github.com/nodejs/Release/blob/master/README.md